### PR TITLE
Remove unnecessary Boxing

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -2,11 +2,10 @@
 // use std::rc::Rc;
 use crate::droplet::RxDroplet;
 
-type Edges = Vec<Box<RxDroplet>>;
-
+#[derive(Clone)]
 pub struct Block {
     pub idx: usize,
-    pub edges: Edges,
+    pub edges: Vec<RxDroplet>,
     pub begin_at: usize,
     pub is_known: bool,
 }
@@ -14,7 +13,7 @@ pub struct Block {
 impl Block {
     pub fn new(
         idx: usize,
-        edges: Edges,
+        edges: Vec<RxDroplet>,
         begin_at: usize,
         is_known: bool ) -> Block {
         Block {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -85,8 +85,8 @@ impl Decoder {
     }
 
     fn process_droplet(&mut self, droplet: RxDroplet) {
-        let mut drops: Vec<Box<RxDroplet>> = Vec::new();
-        drops.push(Box::new(droplet));
+        let mut drops: Vec<RxDroplet> = Vec::new();
+        drops.push(droplet);
         loop {
             // a loop is used instead of recursion
             match drops.pop() {


### PR DESCRIPTION
I believe these `Box`es were added to replace the `Rc`s in the original code-base. As far as I can tell, those original `Rc`s were entirely unnecessary to begin with. I checked that `erlang-erasure` still compiles with these changes. Additionally, I did not fix any unrelated warnings since some are fixed by #4 and I plan on opening a more comprehensive cleanup PR after these two PRs merge.