### PR TITLE
Add vectorized byte-slice xor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,14 @@ repository = "https://github.com/chrido/fountain.git"
 license = "MIT/Apache-2.0"
 keywords = ["FEC", "ErrorCorrection", "FountainCode"]
 
+[features]
+# Enable NEON SIMD instructions on arm targets. Requires nightly
+# compiler.
+arm-neon = []
+
+[profile.release]
+debug = true
+
 [dependencies]
 rand = "0.7.3"
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -2,6 +2,7 @@ use crate::{
     block::Block,
     droplet::{DropType, Droplet, RxDroplet},
     encoder::get_sample_from_rng_by_seed,
+    xor::xor_bytes,
 };
 use rand::distributions::Uniform;
 
@@ -89,9 +90,10 @@ impl Decoder {
                 let block = self.blocks.get_mut(ed).unwrap();
                 if block.is_known {
                     let mut b_drop = drop.clone();
-                    for i in 0..self.blocksize {
-                        b_drop.data[i] ^= self.data[block.begin_at + i];
-                    }
+                    xor_bytes(
+                        &mut b_drop.data[..self.blocksize],
+                        &self.data[block.begin_at..],
+                    );
                     let pos = b_drop.edges_idx.iter().position(|x| x == &ed).unwrap();
                     b_drop.edges_idx.remove(pos);
                 } else {
@@ -119,9 +121,10 @@ impl Decoder {
                         if m_edge.edges_idx.len() == 1 {
                             drops.push(edge);
                         } else {
-                            for i in 0..self.blocksize {
-                                m_edge.data[i] ^= self.data[block.begin_at + i]
-                            }
+                            xor_bytes(
+                                &mut m_edge.data[..self.blocksize],
+                                &self.data[block.begin_at..],
+                            );
 
                             let pos = m_edge
                                 .edges_idx

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,6 +1,7 @@
 use crate::{
     droplet::{DropType, Droplet},
     soliton::Soliton,
+    xor::xor_bytes,
 };
 use rand::{
     distributions::{Distribution, Uniform},
@@ -101,10 +102,7 @@ impl Encoder {
                 for k in sample {
                     let begin = k * self.blocksize;
                     let end = cmp::min((k + 1) * self.blocksize, self.len);
-
-                    for (src_dat, drop_dat) in self.data[begin..end].iter().zip(r.iter_mut()) {
-                        *drop_dat ^= src_dat;
-                    }
+                    xor_bytes(&mut r, &self.data[begin..end]);
                 }
                 Droplet::new(DropType::Seeded(seed, degree), r)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod decoder;
 pub mod droplet;
 pub mod encoder;
 pub mod soliton;
+mod xor;

--- a/src/xor.rs
+++ b/src/xor.rs
@@ -1,0 +1,61 @@
+#![cfg_attr(
+    all(
+        feature = "arm-neon",
+        any(target_arch = "arm", target_arch = "aarch64")
+    ),
+    feature(arm_target_feature),
+    feature(stdsimd)
+)]
+
+// Computing the XOR of two byte slices, `lhs` & `rhs`.
+// `lhs` is mutated in-place with the result
+pub fn xor_bytes(lhs: &mut [u8], rhs: &[u8]) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if is_x86_feature_detected!("avx2") {
+            return unsafe { xor_bytes_avx2(lhs, rhs) };
+        } else if is_x86_feature_detected!("sse2") {
+            return unsafe { xor_bytes_sse2(lhs, rhs) };
+        }
+    }
+
+    #[cfg(all(
+        feature = "arm-neon",
+        any(target_arch = "arm", target_arch = "aarch64")
+    ))]
+    {
+        if is_arm_feature_detected!("neon") {
+            return unsafe { xor_bytes_neon(lhs, rhs) };
+        }
+    }
+
+    xor_bytes_fallback(lhs, rhs);
+}
+
+#[inline(always)]
+fn xor_bytes_fallback(lhs: &mut [u8], rhs: &[u8]) {
+    for (l, r) in lhs.iter_mut().zip(rhs) {
+        *l ^= *r;
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+unsafe fn xor_bytes_avx2(lhs: &mut [u8], rhs: &[u8]) {
+    xor_bytes_fallback(lhs, rhs);
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "sse2")]
+unsafe fn xor_bytes_sse2(lhs: &mut [u8], rhs: &[u8]) {
+    xor_bytes_fallback(lhs, rhs);
+}
+
+#[cfg(all(
+    feature = "arm-neon",
+    any(target_arch = "arm", target_arch = "aarch64")
+))]
+#[target_feature(enable = "neon")]
+unsafe fn xor_bytes_neon(lhs: &mut [u8], rhs: &[u8]) {
+    xor_bytes_fallback(lhs, rhs);
+}


### PR DESCRIPTION
This seems to a give decent little speedup in tests, but keep in mind the tests in this crate make liberal use of `println!`, this execution is dominated IO.

See generated code at https://godbolt.org/z/zWrzvE

## Remaining

- [x] add Arm imply
- [x] add Aarch64 imp
