### PR TITLE
Move test-vector generation out of hot path

### DIFF
--- a/benches/decoder_benchmark.rs
+++ b/benches/decoder_benchmark.rs
@@ -10,61 +10,17 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 
 fn robust_enc_dec_helper(
-    total_len: usize,
     chunk_len: usize,
     loss: f32,
     c: f32,
     spike: Option<usize>,
     delta: f32,
     enc_type: EncoderType,
+    msg: Vec<u8>,
 ) {
-    let s: String = thread_rng()
-        .sample_iter(Alphanumeric)
-        .take(total_len)
-        .collect();
-    let buf = s.into_bytes();
-    let len = buf.len();
-    let to_compare = buf.clone();
-
-    let mut enc = RobustEncoder::new(buf, chunk_len, enc_type, c, spike, delta);
-    let mut dec = Decoder::new(len, chunk_len);
-
-    let mut loss_rng = thread_rng();
-
-    loop {
-        let drop = enc.next();
-        if loss_rng.gen::<f32>() > loss {
-            match dec.catch(drop) {
-                CatchResult::Missing(_stats) => {
-                    //a systematic encoder and no loss on channel should only need k symbols
-                    //assert_eq!(stats.cnt_chunks-stats.unknown_chunks, cnt_drops)
-                    // println!("Missing blocks {:?}", stats);
-                }
-                CatchResult::Finished(data, _stats) => {
-                    // println!("Finished, stats: {:?}", _stats);
-                    assert_eq!(to_compare.len(), data.len());
-                    for i in 0..len {
-                        assert_eq!(to_compare[i], data[i]);
-                    }
-                    return;
-                }
-            }
-        }
-    }
-}
-
-fn ideal_enc_dec_helper(total_len: usize, chunk_len: usize, loss: f32, enc_type: EncoderType) {
-    let s: String = thread_rng()
-        .sample_iter(Alphanumeric)
-        .take(total_len)
-        .collect();
-    let buf = s.into_bytes();
-    let len = buf.len();
-    let to_compare = buf.clone();
-
-    let mut enc = IdealEncoder::new(buf, chunk_len, enc_type);
-    let mut dec = Decoder::new(len, chunk_len);
-
+    let to_compare = msg.clone();
+    let mut enc = RobustEncoder::new(msg, chunk_len, enc_type, c, spike, delta);
+    let mut dec = Decoder::new(to_compare.len(), chunk_len);
     let mut loss_rng = thread_rng();
 
     loop {
@@ -73,10 +29,27 @@ fn ideal_enc_dec_helper(total_len: usize, chunk_len: usize, loss: f32, enc_type:
             match dec.catch(drop) {
                 CatchResult::Missing(_stats) => {}
                 CatchResult::Finished(data, _stats) => {
-                    assert_eq!(to_compare.len(), data.len());
-                    for i in 0..len {
-                        assert_eq!(to_compare[i], data[i]);
-                    }
+                    assert_eq!(data, to_compare);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn ideal_enc_dec_helper(chunk_len: usize, loss: f32, enc_type: EncoderType, msg: Vec<u8>) {
+    let to_compare = msg.clone();
+    let mut enc = IdealEncoder::new(msg, chunk_len, enc_type);
+    let mut dec = Decoder::new(to_compare.len(), chunk_len);
+    let mut loss_rng = thread_rng();
+
+    loop {
+        let drop = enc.next();
+        if loss_rng.gen::<f32>() > loss {
+            match dec.catch(drop) {
+                CatchResult::Missing(_stats) => {}
+                CatchResult::Finished(data, _stats) => {
+                    assert_eq!(data, to_compare);
                     return;
                 }
             }
@@ -96,26 +69,33 @@ fn bench_ideal_vs_robust(c: &mut Criterion) {
     let robust_delta = 0.05;
 
     for (size, chunk, loss) in iproduct!(&sizes, &chunks, &losses) {
+        let msg: Vec<u8> = thread_rng()
+            .sample_iter(Alphanumeric)
+            .take(*size)
+            .collect::<String>()
+            .into_bytes();
+
         group.bench_with_input(
             BenchmarkId::from_parameter(format!("Ideal_{}_{}_{}", size, chunk, loss)),
-            size,
-            |b, size| {
-                b.iter(|| ideal_enc_dec_helper(*size, *chunk, *loss, EncoderType::Systematic))
+            &(chunk, loss, msg.clone()),
+            |b, (&chunk, &loss, msg)| {
+                b.iter(|| ideal_enc_dec_helper(chunk, loss, EncoderType::Systematic, msg.to_vec()))
             },
         );
+
         group.bench_with_input(
             BenchmarkId::from_parameter(format!("Robust_{}_{}_{}", size, chunk, loss)),
-            size,
-            |b, size| {
+            &(chunk, loss, msg),
+            |b, (&chunk, &loss, msg)| {
                 b.iter(|| {
                     robust_enc_dec_helper(
-                        *size,
-                        *chunk,
-                        *loss,
+                        chunk,
+                        loss,
                         robust_c,
                         None,
                         robust_delta,
                         EncoderType::Systematic,
+                        msg.to_vec(),
                     )
                 })
             },


### PR DESCRIPTION
A lot of what the benchmarks are currently measuring is the time to generate random messages. Let's move that message generation outsize of the benchmarked functions.